### PR TITLE
Position subviews correctly when cell align is set.

### DIFF
--- a/WeView/Layouts/WeViewLayout+Subclass.h
+++ b/WeView/Layouts/WeViewLayout+Subclass.h
@@ -55,6 +55,12 @@
 - (CGSize)desiredItemSize:(UIView *)subview
                   maxSize:(CGSize)maxSize;
 
+// The horizontal alignment of a subview in this layout.
+- (HAlign)subviewCellHAlign:(UIView *)subview;
+
+// The vertical alignment of a subview in this layout.
+- (VAlign)subviewCellVAlign:(UIView *)subview;
+
 + (NSArray *)distributeSpace:(CGFloat)space
       acrossCellsWithWeights:(NSArray *)cellWeights;
 

--- a/WeView/Layouts/WeViewLayout.h
+++ b/WeView/Layouts/WeViewLayout.h
@@ -80,12 +80,10 @@
 - (WeViewLayout *)setVAlign:(VAlign)value;
 
 // The horizontal alignment of a subview in this layout.
-- (HAlign)subviewCellHAlign:(UIView *)view
-                    subview:(UIView *)subview;
+- (HAlign)subviewCellHAlign:(UIView *)subview;
 
 // The vertical alignment of a subview in this layout.
-- (VAlign)subviewCellVAlign:(UIView *)view
-                    subview:(UIView *)subview;
+- (VAlign)subviewCellVAlign:(UIView *)subview;
 
 // By default, if the content size (ie. the total subview size plus margins and spacing) of a
 // WeView overflows its bounds, subviews are cropped to fit inside the available

--- a/WeView/Layouts/WeViewLayout.h
+++ b/WeView/Layouts/WeViewLayout.h
@@ -79,12 +79,6 @@
 - (VAlign)vAlign;
 - (WeViewLayout *)setVAlign:(VAlign)value;
 
-// The horizontal alignment of a subview in this layout.
-- (HAlign)subviewCellHAlign:(UIView *)subview;
-
-// The vertical alignment of a subview in this layout.
-- (VAlign)subviewCellVAlign:(UIView *)subview;
-
 // By default, if the content size (ie. the total subview size plus margins and spacing) of a
 // WeView overflows its bounds, subviews are cropped to fit inside the available
 // space.

--- a/WeView/Layouts/WeViewLayout.h
+++ b/WeView/Layouts/WeViewLayout.h
@@ -79,6 +79,14 @@
 - (VAlign)vAlign;
 - (WeViewLayout *)setVAlign:(VAlign)value;
 
+// The horizontal alignment of a subview in this layout.
+- (HAlign)subviewCellHAlign:(UIView *)view
+                    subview:(UIView *)subview;
+
+// The vertical alignment of a subview in this layout.
+- (VAlign)subviewCellVAlign:(UIView *)view
+                    subview:(UIView *)subview;
+
 // By default, if the content size (ie. the total subview size plus margins and spacing) of a
 // WeView overflows its bounds, subviews are cropped to fit inside the available
 // space.

--- a/WeView/Layouts/WeViewLayout.m
+++ b/WeView/Layouts/WeViewLayout.m
@@ -349,8 +349,7 @@ BOOL _debugMinSize;
     return self._superview;
 }
 
-- (HAlign)subviewCellHAlign:(UIView *)superview
-                    subview:(UIView *)subview
+- (HAlign)subviewCellHAlign:(UIView *)subview
 {
     if (subview.hasCellHAlign)
     {
@@ -359,8 +358,7 @@ BOOL _debugMinSize;
     return _hAlign;
 }
 
-- (VAlign)subviewCellVAlign:(UIView *)view
-                    subview:(UIView *)subview
+- (VAlign)subviewCellVAlign:(UIView *)subview
 {
     if (subview.hasCellVAlign)
     {
@@ -435,10 +433,8 @@ BOOL _debugMinSize;
             subviewSize = CGSizeMax(CGSizeZero, CGSizeFloor(subviewSize));
             subview.frame = [self alignSize:subviewSize
                                  withinRect:cellBounds
-                                     hAlign:[self subviewCellHAlign:superview
-                                                            subview:subview]
-                                     vAlign:[self subviewCellVAlign:superview
-                                                            subview:subview]];
+                                     hAlign:[self subviewCellHAlign:subview]
+                                     vAlign:[self subviewCellVAlign:subview]];
             break;
         }
         case CELL_POSITIONING_FILL:
@@ -474,10 +470,8 @@ BOOL _debugMinSize;
                 subviewSize = CGSizeMax(CGSizeZero, CGSizeFloor(subviewSize));
                 subview.frame = [self alignSize:subviewSize
                                      withinRect:cellBounds
-                                         hAlign:[self subviewCellHAlign:superview
-                                                                subview:subview]
-                                         vAlign:[self subviewCellVAlign:superview
-                                                                subview:subview]];
+                                         hAlign:[self subviewCellHAlign:subview]
+                                         vAlign:[self subviewCellVAlign:subview]];
             }
         }
         default:

--- a/WeView/Layouts/WeViewLinearLayout.m
+++ b/WeView/Layouts/WeViewLinearLayout.m
@@ -369,13 +369,9 @@
 
 - (CGFloat)hAlignIndex:(CGFloat)index
             extraSpace:(CGFloat)extraSpace
-             superview:(UIView *)superview
                subview:(UIView *)subview
 {
-    HAlign cellHAlign = [self subviewCellHAlign:superview
-                                        subview:subview];
-    
-    switch (cellHAlign)
+    switch ([self subviewCellHAlign:subview])
     {
         case H_ALIGN_LEFT:
             return index;
@@ -391,13 +387,9 @@
 
 - (CGFloat)vAlignIndex:(CGFloat)index
             extraSpace:(CGFloat)extraSpace
-             superview:(UIView *)superview
                subview:(UIView *)subview
 {
-    VAlign cellVAlign = [self subviewCellVAlign:superview
-                                        subview:subview];
-    
-    switch (cellVAlign)
+    switch ([self subviewCellVAlign:subview])
     {
         case V_ALIGN_TOP:
             return index;
@@ -583,6 +575,28 @@
               extraAxisSpace,
               extraCrossSpace);
     }
+    
+    // Honor the axis alignment.
+    if (horizontal)
+    {
+        axisIndex = [self hAlignIndex:axisIndex
+                           extraSpace:extraAxisSpace
+                              subview:nil];
+    }
+    else
+    {
+        axisIndex = [self vAlignIndex:axisIndex
+                           extraSpace:extraAxisSpace
+                              subview:nil];
+    }
+    
+    if (debugLayout)
+    {
+        NSLog(@"%@ bodyCrossSize: %f, axisIndex: %f",
+              [self indentPrefix:indent + 1],
+              bodyCrossSize,
+              axisIndex);
+    }
 
     // Calculate and apply the subviews' frames.
     CellPositioningMode cellPositioning = [self cellPositioning];
@@ -590,51 +604,38 @@
     {
         UIView* subview = subviews[i];
         
-        CGFloat cellAxisIndex = axisIndex;
         CGFloat cellCrossIndex = crossIndex;
         
-        // Honor the axis alignment.
+        // Honor the cross axis alignment.
         if (horizontal)
         {
-            cellAxisIndex = [self hAlignIndex:axisIndex
-                                   extraSpace:extraAxisSpace
-                                    superview:view
-                                      subview:subview];
             if (!hasCellWithCrossStretch)
             {
                 cellCrossIndex = [self vAlignIndex:crossIndex
                                         extraSpace:extraCrossSpace
-                                         superview:view
                                            subview:subview];
             }
         }
         else
         {
-            cellAxisIndex = [self vAlignIndex:axisIndex
-                                   extraSpace:extraAxisSpace
-                                    superview:view
-                                      subview:subview];
             if (!hasCellWithCrossStretch)
             {
                 cellCrossIndex = [self hAlignIndex:crossIndex
                                         extraSpace:extraCrossSpace
-                                         superview:view
                                            subview:subview];
             }
         }
         
         if (debugLayout)
         {
-            NSLog(@"%@ - [%d] bodyCrossSize: %f, cellAxisIndex: %f, cellCrossIndex: %f",
+            NSLog(@"%@ cellCrossIndex[%d]: %f",
                   [self indentPrefix:indent + 2],
                   i,
-                  bodyCrossSize,
-                  cellAxisIndex,
                   cellCrossIndex);
         }
         
-        CGRect cellBounds = CGRectMake(horizontal ? cellAxisIndex : cellCrossIndex,
-                                       horizontal ? cellCrossIndex : cellAxisIndex,
+        CGRect cellBounds = CGRectMake(horizontal ? axisIndex : cellCrossIndex,
+                                       horizontal ? cellCrossIndex : axisIndex,
                                        horizontal ? [cellAxisSizes[i] floatValue] : bodyCrossSize,
                                        horizontal ? bodyCrossSize : [cellAxisSizes[i] floatValue]);
 

--- a/WeView/Layouts/WeViewLinearLayout.m
+++ b/WeView/Layouts/WeViewLinearLayout.m
@@ -367,43 +367,47 @@
     }
 }
 
-- (void)hAlignIndex:(CGFloat *)index
-         extraSpace:(CGFloat)extraSpace
-               view:(UIView *)view
+- (CGFloat)hAlignIndex:(CGFloat)index
+            extraSpace:(CGFloat)extraSpace
+             superview:(UIView *)superview
+               subview:(UIView *)subview
 {
-    switch ([self hAlign])
+    HAlign cellHAlign = [self subviewCellHAlign:superview
+                                        subview:subview];
+    
+    switch (cellHAlign)
     {
         case H_ALIGN_LEFT:
-            break;
+            return index;
         case H_ALIGN_CENTER:
-            *index = *index + roundf(extraSpace / 2);
-            break;
+            return index + roundf(extraSpace / 2);
         case H_ALIGN_RIGHT:
-            *index = *index + extraSpace;
-            break;
+            return index + extraSpace;
         default:
             WeViewAssert(0);
-            break;
+            return index;
     }
 }
 
-- (void)vAlignIndex:(CGFloat *)index
-         extraSpace:(CGFloat)extraSpace
-               view:(UIView *)view
+- (CGFloat)vAlignIndex:(CGFloat)index
+            extraSpace:(CGFloat)extraSpace
+             superview:(UIView *)superview
+               subview:(UIView *)subview
 {
-    switch ([self vAlign])
+    VAlign cellVAlign = [self subviewCellVAlign:superview
+                                        subview:subview];
+    
+    switch (cellVAlign)
     {
         case V_ALIGN_TOP:
-            break;
+            return index;
         case V_ALIGN_CENTER:
-            *index = *index + roundf(extraSpace / 2);
-            break;
+            return index + roundf(extraSpace / 2);
         case V_ALIGN_BOTTOM:
-            *index = *index + extraSpace;
-            break;
+            return index + extraSpace;
         default:
             WeViewAssert(0);
-            break;
+            return index;
     }
 }
 
@@ -580,49 +584,57 @@
               extraCrossSpace);
     }
 
-    // Honor the axis alignment.
-    if (horizontal)
-    {
-        [self hAlignIndex:&axisIndex
-               extraSpace:extraAxisSpace
-                     view:view];
-        if (!hasCellWithCrossStretch)
-        {
-            [self vAlignIndex:&crossIndex
-                   extraSpace:extraCrossSpace
-                         view:view];
-        }
-    }
-    else
-    {
-        [self vAlignIndex:&axisIndex
-               extraSpace:extraAxisSpace
-                     view:view];
-        if (!hasCellWithCrossStretch)
-        {
-            [self hAlignIndex:&crossIndex
-                   extraSpace:extraCrossSpace
-                         view:view];
-        }
-    }
-
-    if (debugLayout)
-    {
-        NSLog(@"%@ bodyCrossSize: %f, axisIndex: %f, crossIndex: %f",
-              [self indentPrefix:indent + 1],
-              bodyCrossSize,
-              axisIndex,
-              crossIndex);
-    }
-
     // Calculate and apply the subviews' frames.
     CellPositioningMode cellPositioning = [self cellPositioning];
     for (int i=0; i < subviewCount; i++)
     {
         UIView* subview = subviews[i];
-
-        CGRect cellBounds = CGRectMake(horizontal ? axisIndex : crossIndex,
-                                       horizontal ? crossIndex : axisIndex,
+        
+        CGFloat cellAxisIndex = axisIndex;
+        CGFloat cellCrossIndex = crossIndex;
+        
+        // Honor the axis alignment.
+        if (horizontal)
+        {
+            cellAxisIndex = [self hAlignIndex:axisIndex
+                                   extraSpace:extraAxisSpace
+                                    superview:view
+                                      subview:subview];
+            if (!hasCellWithCrossStretch)
+            {
+                cellCrossIndex = [self vAlignIndex:crossIndex
+                                        extraSpace:extraCrossSpace
+                                         superview:view
+                                           subview:subview];
+            }
+        }
+        else
+        {
+            cellAxisIndex = [self vAlignIndex:axisIndex
+                                   extraSpace:extraAxisSpace
+                                    superview:view
+                                      subview:subview];
+            if (!hasCellWithCrossStretch)
+            {
+                cellCrossIndex = [self hAlignIndex:crossIndex
+                                        extraSpace:extraCrossSpace
+                                         superview:view
+                                           subview:subview];
+            }
+        }
+        
+        if (debugLayout)
+        {
+            NSLog(@"%@ - [%d] bodyCrossSize: %f, cellAxisIndex: %f, cellCrossIndex: %f",
+                  [self indentPrefix:indent + 2],
+                  i,
+                  bodyCrossSize,
+                  cellAxisIndex,
+                  cellCrossIndex);
+        }
+        
+        CGRect cellBounds = CGRectMake(horizontal ? cellAxisIndex : cellCrossIndex,
+                                       horizontal ? cellCrossIndex : cellAxisIndex,
                                        horizontal ? [cellAxisSizes[i] floatValue] : bodyCrossSize,
                                        horizontal ? bodyCrossSize : [cellAxisSizes[i] floatValue]);
 


### PR DESCRIPTION
Scenario:

Subview in a horizontal layout is placed inside a view that has a fixedDesiredHeight smaller than its desired height. When valign is set to top on the parent, the subview is correctly vertically aligned within the smaller fixedDesiredHeight. But when cellVAlign is set to top on the subview, the subview is vertically placed within the larger desired height. This is because positionSubview is using the wrong cellBounds.

Example:

```
    WeView *yellowView = [[WeView alloc] init];
    yellowView.backgroundColor = [UIColor yellowColor];
    yellowView.fixedDesiredHeight = 300;
    [view addSubviewWithCustomLayout:yellowView];
    
    UIImageView *redImageView = [[UIImageView alloc] initWithImage:[UIImage imageWithColor:[UIColor redColor] size:CGSizeMake(50, 400)]];
    UIImageView *blueImageView = [[UIImageView alloc] initWithImage:[UIImage imageWithColor:[UIColor blueColor] size:CGSizeMake(50, 100)]];
    
    [[yellowView addSubviewsWithHorizontalLayout:@[redImageView, blueImageView]]
     setVAlign:V_ALIGN_TOP];
```

Yields correct top-aligned layout:
![screenshot 2015-03-06 12 18 56](https://cloud.githubusercontent.com/assets/5578654/6535758/4a79a00e-c3fc-11e4-845b-b9b9cc2116c0.png)

```
    WeView *yellowView = [[WeView alloc] init];
    yellowView.backgroundColor = [UIColor yellowColor];
    yellowView.fixedDesiredHeight = 300;
    [view addSubviewWithCustomLayout:yellowView];
    
    UIImageView *redImageView = [[UIImageView alloc] initWithImage:[UIImage imageWithColor:[UIColor redColor] size:CGSizeMake(50, 400)]];
    UIImageView *blueImageView = [[UIImageView alloc] initWithImage:[UIImage imageWithColor:[UIColor blueColor] size:CGSizeMake(50, 100)]];
    
    [[yellowView addSubviewsWithHorizontalLayout:@[redImageView, blueImageView]]
     setVAlign:V_ALIGN_CENTER];
```
Yields correct center-aligned layout:
![screenshot 2015-03-06 12 20 47](https://cloud.githubusercontent.com/assets/5578654/6535750/421edfdc-c3fc-11e4-8fe4-7c8576709788.png)

```
    WeView *yellowView = [[WeView alloc] init];
    yellowView.backgroundColor = [UIColor yellowColor];
    yellowView.fixedDesiredHeight = 300;
    [view addSubviewWithCustomLayout:yellowView];
    
    UIImageView *redImageView = [[UIImageView alloc] initWithImage:[UIImage imageWithColor:[UIColor redColor] size:CGSizeMake(50, 400)]];
    redImageView.cellVAlign = V_ALIGN_TOP;
    UIImageView *blueImageView = [[UIImageView alloc] initWithImage:[UIImage imageWithColor:[UIColor blueColor] size:CGSizeMake(50, 100)]];
    
    [[yellowView addSubviewsWithHorizontalLayout:@[redImageView, blueImageView]]
     setVAlign:V_ALIGN_CENTER];
```
Yields incorrect layout of red block:
![screenshot 2015-03-06 12 20 47](https://cloud.githubusercontent.com/assets/5578654/6535782/7a7d87ca-c3fc-11e4-9e21-6c9b235e80c5.png)

With fix applied, the new result properly aligns red to top:
![screenshot 2015-03-06 12 31 38](https://cloud.githubusercontent.com/assets/5578654/6535830/d2df6898-c3fc-11e4-8b98-ae28061cee25.png)

PTAL @charlesmchen 