### PR TITLE
Mirror desired size adjustments in WeViewProxyView.

### DIFF
--- a/WeView/WeViewProxyView.m
+++ b/WeView/WeViewProxyView.m
@@ -9,6 +9,7 @@
 //
 
 #import "WeViewProxyView.h"
+#import "UIView+WeView.h"
 
 @interface WeViewProxyView ()
 
@@ -48,6 +49,24 @@
 {
     UIView *view = self.isWeakReference ? self.weakView : self.strongView;
     return [view sizeThatFits:size];
+}
+
+- (CGSize)maxDesiredSize
+{
+    UIView *view = self.isWeakReference ? self.weakView : self.strongView;
+    return view.maxDesiredSize;
+}
+
+- (CGSize)minDesiredSize
+{
+    UIView *view = self.isWeakReference ? self.weakView : self.strongView;
+    return view.minDesiredSize;
+}
+
+- (CGSize)desiredSizeAdjustment
+{
+    UIView *view = self.isWeakReference ? self.weakView : self.strongView;
+    return view.desiredSizeAdjustment;
 }
 
 + (WeViewProxyView*)proxyWithView:(UIView *)view


### PR DESCRIPTION
WeProxyView wasn't mirroring the size of a label because that label had a maxDesiredSize set on it.

`- (CGSize)desiredItemSize:(UIView *)subview maxSize:(CGSize)maxSize` depends on `maxDesiredSize`, `desiredSizeAdjustment`, and `minDesiredSize` so I made the proxy view mirror these properties. I wasn't sure if I should do the same for `ignoreDesiredSize`.

This also opens the question for spacing adjustments. I'd think those could be adjusted independently on the proxy views, so those shouldn't be mirrored.

This PR might be the wrong approach. Maybe it should be the job of the proxy view's owner to copy over the desired size adjustments.

ptal @charlesmchen 

